### PR TITLE
Fix `.tabulator-col-sorter` z-index

### DIFF
--- a/static/css/toh.css
+++ b/static/css/toh.css
@@ -1092,7 +1092,7 @@ A.toh-but:hover{
 	position: absolute;
 	top: 30px;
 	right: 0;
-	z-index: 1000;
+	z-index: 10;
 }
 
 #toh-table .tabulator-header-filter INPUT:focus {


### PR DESCRIPTION
When `Columns = ALL`, scrolling to the right causes redundant arrows to appear on the headers of the first two pinned columns.