### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "GitHub/CI"


### PR DESCRIPTION
Add Dependabot configuration to automatically maintain GitHub Actions dependencies. Configuration follows the OpenWrt/LuCI repository style for consistency across the ecosystem.