### PR TITLE
feat: show device images in a lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
 								<li>Add multiple sorting criteria by holding Shift while clicking column headers</li>
 								<li>Reorder columns by dragging their headers left or right</li>
 								<li>Adjust column width by dragging the border between columns</li>
-								<li>View images by hovering over picture icons</li>
+								<li>View images by hovering over picture icons, or click them for a larger view</li>
 								<li>Sort a column by clicking its header (toggles between asc., desc., and no order)</li>
 								<li>Store/recall your own filters or column presets by using the right tabs (1, 2, 3)</li>
 							</ul>

--- a/static/css/toh.css
+++ b/static/css/toh.css
@@ -1006,11 +1006,28 @@ A.toh-but:hover{
 	opacity: 0.5;
 	color: red;
 }
+/* how many pictures the single icon stands for */
+#toh-table .tabulator-cell .cell-image-count{
+	font-size: 9px;
+	font-weight: 700;
+	vertical-align: super;
+	margin-left: -3px;
+	color: #0081b3;
+}
+
+/* the preview says why it is empty rather than showing nothing at all */
+#toh-image-preview .toh-preview-error{
+	padding: 8px 12px;
+	font-size: 12px;
+	line-height: 1.4;
+	color: #a00;
+	max-width: 220px;
+}
+
+/* not a link: it marks a device that has no picture of its own */
 #toh-table-container .tabulator-cell .cell-image.generic{
 	color: #ccc;
-}
-#toh-table .tabulator-cell .cell-image.generic:hover{
-	color: #666;
+	cursor: default;
 }
 
 
@@ -1031,6 +1048,116 @@ A.toh-but:hover{
 	max-height: 300px;
 	display: block;
 	border-radius: 5px;
+}
+
+
+/* Image Lightbox ------------------------------------------- */
+
+#toh-image-lightbox {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 10010; /* over the image preview */
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 20px;
+	background-color: rgba(0,0,0,.6);
+}
+#toh-image-lightbox .toh-lightbox-border{
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
+	max-height: 100%;
+	box-shadow: 4px 4px 10px 2px rgba(0,0,0,0.2);
+	background-color: #fff;
+	border-radius: 5px;
+	/* keeps the head's corners with the box's, no white rim around the title */
+	overflow: hidden;
+}
+#toh-image-lightbox .toh-lightbox-head{
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border-bottom: #111 1px solid;
+	color: #fff;
+	background: linear-gradient(to top, #444 0%,#666 100%);
+	font-size: 14px;
+	line-height: 16px;
+	padding: 4px 10px;
+}
+#toh-image-lightbox .toh-lightbox-source{
+	color: #fff;
+	font-size: 13px;
+	text-decoration: none;
+	opacity: 0.8;
+}
+#toh-image-lightbox .toh-lightbox-source:hover{
+	opacity: 1;
+	text-decoration: underline;
+}
+#toh-image-lightbox .toh-lightbox-counter{
+	color: #fff;
+	font-size: 12px;
+	opacity: 0.85;
+	padding: 0 10px;
+}
+#toh-image-lightbox .toh-lightbox-body{
+	display: flex;
+	align-items: center;
+	min-height: 0;
+}
+#toh-image-lightbox .toh-lightbox-nav{
+	flex: 0 0 auto;
+	border: 0;
+	background: transparent;
+	color: #888;
+	font-size: 20px;
+	padding: 10px 14px;
+	cursor: pointer;
+	align-self: stretch;
+}
+#toh-image-lightbox .toh-lightbox-nav:hover{
+	color: #0081b3;
+	background-color: rgba(0,0,0,.04);
+}
+#toh-image-lightbox .toh-lightbox-close{
+	line-height: 100%;
+	opacity: 0.6;
+}
+#toh-image-lightbox .toh-lightbox-close:hover{
+	cursor: pointer;
+	opacity: 1;
+}
+#toh-image-lightbox .toh-lightbox-content{
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: auto;
+	min-width: 120px;
+	min-height: 120px;
+	padding: 5px;
+	color: #666;
+}
+#toh-image-lightbox .toh-lightbox-content img{
+	display: block;
+	max-width: 100%;
+	/* head, paddings and the container's own 20px margin */
+	max-height: calc(100vh - 80px);
+	object-fit: contain;
+}
+#toh-image-lightbox .toh-lightbox-error{
+	padding: 20px;
+	font-size: 14px;
+	color: #a00;
+	text-align: center;
+}
+#toh-image-lightbox .toh-lightbox-error A{
+	display: inline-block;
+	margin-top: 10px;
+	color: #0081b3;
 }
 
 

--- a/static/js/toh_main.js
+++ b/static/js/toh_main.js
@@ -1014,6 +1014,120 @@ function positionPreview($link, $container) {
 	});
 }
 
+// Every picture a cell's image link stands for --------------------
+// The icon carries the whole set, so the lightbox can page through it.
+function imagesOfLink($link){
+	var list=$link.attr('data-images');
+	if(list){
+		return list.split(' ').filter(function(url){ return url.length > 0; });
+	}
+	return [$link.attr('href')];
+}
+
+// Open the Image Lightbox --------------------------------------
+// Takes the whole set of pictures a device has, so the arrows can page
+// through them without going back to the table.
+function OpenImageLightbox(urls, index) {
+	if(typeof urls == 'string'){
+		urls=[urls];
+	}
+	if(!Array.isArray(urls) || urls.length == 0){
+		return;
+	}
+	CloseImageLightbox();
+
+	var current=index > 0 ? index : 0;
+	var many=urls.length > 1;
+	var token=0;	// tells a slow image that the arrows have moved on without it
+
+	var $box = $(
+		'<div id="toh-image-lightbox">' +
+			'<div class="toh-lightbox-border">' +
+				'<div class="toh-lightbox-head">' +
+					'<a class="toh-lightbox-source" target="_blank" rel="noopener" title="Open the image in a new tab"><i class="fa-solid fa-up-right-from-square"></i> Open original</a>' +
+					'<span class="toh-lightbox-counter"></span>' +
+					'<div class="toh-lightbox-close" title="Close (Esc)"><i class="fa-solid fa-circle-xmark"></i></div>' +
+				'</div>' +
+				'<div class="toh-lightbox-body">' +
+					'<button type="button" class="toh-lightbox-nav toh-lightbox-prev" title="Previous picture"><i class="fa-solid fa-chevron-left"></i></button>' +
+					'<div class="toh-lightbox-content"></div>' +
+					'<button type="button" class="toh-lightbox-nav toh-lightbox-next" title="Next picture"><i class="fa-solid fa-chevron-right"></i></button>' +
+				'</div>' +
+			'</div>' +
+		'</div>'
+	);
+	if(!many){
+		$box.find('.toh-lightbox-nav').remove();
+	}
+
+	function showImage(wanted){
+		current=(wanted + urls.length) % urls.length;	// the arrows wrap around
+		var url=urls[current];
+		var mine=++token;
+
+		$box.find('.toh-lightbox-source').attr('href', url);
+		$box.find('.toh-lightbox-counter').text(many ? (current + 1) + ' / ' + urls.length : '');
+		$box.find('.toh-lightbox-content').html('<i class="fa-solid fa-arrows-rotate fa-spin fa-2x"></i>');
+
+		var $img = $('<img>', {alt: 'Device Image'});
+		$img.on('load', function() {
+			if(mine != token){
+				return;
+			}
+			$box.find('.toh-lightbox-content').empty().append($img);
+		});
+		$img.on('error', function() {
+			if(mine != token){
+				return;
+			}
+			// The wiki sits behind an anti-bot challenge that images embedded from
+			// another page cannot answer, so they are served an HTML page instead.
+			// Opening the image as a normal navigation does pass the challenge.
+			var $err = $('<div class="toh-lightbox-error"></div>');
+			$err.append('<div><i class="fa-solid fa-triangle-exclamation"></i> This image could not be loaded from the wiki.</div>');
+			$err.append($('<a target="_blank" rel="noopener">Open it directly on openwrt.org</a>').attr('href', url));
+			$box.find('.toh-lightbox-content').empty().append($err);
+		});
+		$img.attr('src', url);
+	}
+
+	$box.find('.toh-lightbox-prev').on('click', function(e) {
+		e.stopPropagation();
+		showImage(current - 1);
+	});
+	$box.find('.toh-lightbox-next').on('click', function(e) {
+		e.stopPropagation();
+		showImage(current + 1);
+	});
+
+	// close on backdrop click, but not when clicking the image itself
+	$box.on('click', function(e) {
+		if(e.target === this || $(e.target).closest('.toh-lightbox-close').length){
+			CloseImageLightbox();
+		}
+	});
+	$(document).on('keydown.tohlightbox', function(e) {
+		if(e.keyCode == 27){	//esc
+			CloseImageLightbox();
+		}
+		else if(many && e.keyCode == 37){	//left
+			showImage(current - 1);
+		}
+		else if(many && e.keyCode == 39){	//right
+			showImage(current + 1);
+		}
+	});
+
+	$('BODY').append($box);
+	showImage(current);
+}
+
+// Close the Image Lightbox -------------------------------------
+function CloseImageLightbox() {
+	$(document).off('keydown.tohlightbox');
+	$('#toh-image-lightbox').remove();
+}
+
 
 
 var loading_is_running	= false;
@@ -1292,23 +1406,55 @@ $(document).ready(function () {
 
 	// handles Image Preview on hover ----------------------------------------
 	var $container = $('#toh-image-preview');
+	var hoveredLink = null;	// the link the pointer is currently over, guards late load events
+
 	$(document).on({
 		mouseenter: function(e) {
 			var $link = $(this);
-			var imageUrl = $link.attr('href');
-			$container.html('<img src="' + imageUrl + '" alt="Image Preview">');
-		
-			// Wait for the image to load before positioning
-			$container.find('img').on('load', function() {
+			var link = this;
+			hoveredLink = link;
+
+			var $img = $('<img>', {alt: 'Image Preview'});
+			$img.on('load', function() {
+				// a slow image may resolve after the pointer moved on, or after a click
+				// opened the lightbox: only show it if that is still the hovered link
+				if(hoveredLink !== link){
+					return;
+				}
+				$container.empty().append($img).show();
 				positionPreview($link, $container);
 			});
-
-			$container.show();
+			$img.on('error', function() {
+				if(hoveredLink !== link){
+					return;
+				}
+				// Showing nothing looks like the preview itself is broken, so say
+				// what happened. The box is placed either way, which is what went
+				// wrong originally: it was shown but never positioned.
+				$container.empty()
+					.append('<div class="toh-preview-error">Image could not be loaded.<br>Click to open it.</div>')
+					.show();
+				positionPreview($link, $container);
+			});
+			$img.attr('src', $link.attr('href'));
 		},
 		mouseleave: function() {
+			hoveredLink = null;
 			$container.hide().empty();
 		}
 	}, 'a.cell-image');
+
+	// handles Image Lightbox on click ---------------------------------------
+	$(document).on('click', 'a.cell-image', function(e) {
+		// leave modified clicks alone, so opening in a new tab/window still works
+		if(e.which > 1 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey){
+			return;
+		}
+		e.preventDefault();
+		hoveredLink = null;
+		$container.hide().empty();
+		OpenImageLightbox(imagesOfLink($(this)), 0);
+	});
 
 
 	// Observe the DOM to show/hide the loading icon  --------------------------
@@ -2282,7 +2428,8 @@ function isGenerigImage(url){
 function FormatterImages(cell, formatterParams, onRendered) {
 	var arr = cell.getValue();
 	var url='';
-	var out='';
+	var urls=[];
+	var generic=false;
 	if (Array.isArray(arr) && arr.length > 0) {
 		arr.forEach((value, index) => {
 			if(value.match(/^http/)){
@@ -2293,11 +2440,10 @@ function FormatterImages(cell, formatterParams, onRendered) {
 				url=toh_urls.media + value;
 			}
 			if(isGenerigImage(value)){
-				out +='<a href="' + url + '" target="_blank" class="cell-image generic"><i class="fa-fw fa-regular fa-image"></i></a> ';
+				generic=true;
+				return;
 			}
-			else{
-				out +='<a href="' + url + '" target="_blank" class="cell-image"><i class="fa-fw fa-solid fa-image"></i></a> ';
-			}
+			urls.push(url);
 
 			// preload images --------
 			//const img = new Image();
@@ -2308,8 +2454,30 @@ function FormatterImages(cell, formatterParams, onRendered) {
 			}
 
 		});
+
+		if(urls.length == 0){
+			// this device has no photo, only the shared placeholder drawing.
+			// Marking it is useful, offering it to open is not, so this is not
+			// a link: there is nothing to preview and nothing worth opening.
+			if(generic){
+				return '<span class="cell-image generic" title="No picture for this device"><i class="fa-fw fa-regular fa-image"></i></span> ';
+			}
+			return arr;
+		}
+
+		// A handful of devices carry up to six pictures, and one icon each
+		// overflowed the column. One icon stands for the whole set instead, with
+		// the count on it, and the lightbox pages through them.
+		var out='<a href="' + urls[0] + '" target="_blank" class="cell-image"';
+		out +=' data-images="' + urls.join(' ') + '"';
+		out +=' title="' + (urls.length > 1 ? urls.length + ' pictures' : 'Picture') + '">';
+		out +='<i class="fa-fw fa-solid fa-image"></i>';
+		if(urls.length > 1){
+			out +='<span class="cell-image-count">' + urls.length + '</span>';
+		}
+		out +='</a> ';
 		return out;
-	} 
+	}
 	return arr;
 }
 


### PR DESCRIPTION
Clicking a picture icon opened the bare image on the wiki and took you off the table. It now opens in an overlay on the page instead. Esc, the close button or a click outside closes it, and Ctrl/Cmd or middle click still open the original in a new tab.

Devices with several pictures got one icon each, which overflowed the column: three icons need 67px of a 45px cell, and one device carries six. They now get a single icon with the count on it, and the overlay pages through the set with arrows, the left and right keys and a counter.

Devices without a picture of their own carry a shared placeholder drawing, and that icon was a link too. Opening it only ever showed a generic router, so it is now a plain marker.

The hover preview was positioned from the image's load event alone, so an image that failed left an empty box stranded on the page. It is now placed before it is shown, and says when an image could not be loaded rather than leaving the pointer with no answer.

Would be good if https://github.com/openwrt/toh-openwrt-org/issues/41#issuecomment-5082720919 is fixed or there is way how to workaround it,  I could test it only with pictures from 3rd party sources. 